### PR TITLE
fix Datadog codegen for list defaults and colon-bearing strings

### DIFF
--- a/src/caffeine_lang/analysis/templatizer.gleam
+++ b/src/caffeine_lang/analysis/templatizer.gleam
@@ -31,6 +31,7 @@ import caffeine_lang/errors.{type CompilationError}
 import caffeine_lang/helpers.{type ValueTuple}
 import caffeine_lang/types
 import gleam/dict
+import gleam/list
 import gleam/result
 import gleam/string
 
@@ -289,8 +290,8 @@ pub fn resolve_string_value(
   let attr = template.datadog_attr
   case template.template_type {
     Raw -> value
-    Default -> attr <> ":" <> value
-    Not -> "!" <> attr <> ":" <> value
+    Default -> attr <> ":" <> quote_for_datadog(value)
+    Not -> "!" <> attr <> ":" <> quote_for_datadog(value)
   }
 }
 
@@ -307,8 +308,41 @@ pub fn resolve_list_value(
   case template.template_type, values {
     _, [] -> ""
     Raw, values -> values |> string.join(", ")
-    Default, values -> attr <> " IN (" <> values |> string.join(", ") <> ")"
-    Not, values -> attr <> " NOT IN (" <> values |> string.join(", ") <> ")"
+    Default, values ->
+      attr
+      <> " IN ("
+      <> values |> list.map(quote_for_datadog) |> string.join(", ")
+      <> ")"
+    Not, values ->
+      attr
+      <> " NOT IN ("
+      <> values |> list.map(quote_for_datadog) |> string.join(", ")
+      <> ")"
+  }
+}
+
+/// Wraps a value in double quotes when it contains characters that would otherwise
+/// be ambiguous to the Datadog query/tag parser (colons, whitespace, commas,
+/// parentheses). Embedded double quotes are escaped. Values containing wildcards
+/// (`*`) are intentionally left unquoted so wildcard semantics are preserved.
+@internal
+pub fn quote_for_datadog(value: String) -> String {
+  case needs_datadog_quoting(value) {
+    True -> "\"" <> string.replace(value, "\"", "\\\"") <> "\""
+    False -> value
+  }
+}
+
+fn needs_datadog_quoting(value: String) -> Bool {
+  case string.contains(value, "*") {
+    True -> False
+    False ->
+      string.contains(value, ":")
+      || string.contains(value, " ")
+      || string.contains(value, "\t")
+      || string.contains(value, ",")
+      || string.contains(value, "(")
+      || string.contains(value, ")")
   }
 }
 

--- a/src/caffeine_lang/codegen/datadog.gleam
+++ b/src/caffeine_lang/codegen/datadog.gleam
@@ -254,7 +254,9 @@ pub fn ir_to_terraform_resource(
 
   let tags =
     list.append(final_system_tag_pairs, user_tag_pairs)
-    |> list.map(fn(pair) { hcl.StringLiteral(pair.0 <> ":" <> pair.1) })
+    |> list.map(fn(pair) {
+      hcl.StringLiteral(pair.0 <> ":" <> templatizer.quote_for_datadog(pair.1))
+    })
     |> hcl.ListExpr
 
   let identifier = ir_to_identifier(ir)

--- a/src/caffeine_lang/frontend/parser.gleam
+++ b/src/caffeine_lang/frontend/parser.gleam
@@ -1253,6 +1253,10 @@ fn parse_literal_struct_value(
 }
 
 /// Convert a Literal to its string representation for use in refinements/defaults.
+/// List literals are serialized as "[a, b, c]" using the same element format as
+/// types.gleam's value-to-string, so list defaults can be round-tripped at the
+/// resolver. Round-trip via comma-split does not preserve commas embedded inside
+/// individual string elements.
 fn literal_to_string(literal: Literal) -> String {
   case literal {
     ast.LiteralString(s) -> s
@@ -1261,7 +1265,10 @@ fn literal_to_string(literal: Literal) -> String {
     ast.LiteralPercentage(f) -> float.to_string(f) <> "%"
     ast.LiteralTrue -> "true"
     ast.LiteralFalse -> "false"
-    ast.LiteralList(_) -> "[]"
+    ast.LiteralList(elements) ->
+      "["
+      <> elements |> list.map(literal_to_string) |> string.join(", ")
+      <> "]"
     ast.LiteralStruct(_, _) -> "{}"
   }
 }

--- a/src/caffeine_lang/linker/ir_builder.gleam
+++ b/src/caffeine_lang/linker/ir_builder.gleam
@@ -311,7 +311,12 @@ fn resolve_values_for_tag(
     }
     ModifierType(Defaulted(inner, default)) -> {
       case val {
-        value.NilValue -> Ok([default])
+        value.NilValue ->
+          case inner {
+            CollectionType(ListType(_)) ->
+              Ok(types.parse_list_default_string(default))
+            _ -> Ok([default])
+          }
         _ -> resolve_values_for_tag(inner, val)
       }
     }

--- a/src/caffeine_lang/parsing_utils.gleam
+++ b/src/caffeine_lang/parsing_utils.gleam
@@ -7,7 +7,7 @@ import gleam/string
 @internal
 pub fn split_at_top_level_comma(s: String) -> List(String) {
   let chars = string.to_graphemes(s)
-  do_split_at_top_level_comma(chars, 0, 0, [], [])
+  do_split_at_top_level_comma(chars, 0, 0, 0, [], [])
 }
 
 /// Extracts the content inside the outermost pair of parentheses,
@@ -77,6 +77,7 @@ fn do_split_at_top_level_comma(
   chars: List(String),
   paren_depth: Int,
   brace_depth: Int,
+  bracket_depth: Int,
   current: List(String),
   acc: List(String),
 ) -> List(String) {
@@ -93,6 +94,7 @@ fn do_split_at_top_level_comma(
         rest,
         paren_depth + 1,
         brace_depth,
+        bracket_depth,
         ["(", ..current],
         acc,
       )
@@ -101,6 +103,7 @@ fn do_split_at_top_level_comma(
         rest,
         paren_depth - 1,
         brace_depth,
+        bracket_depth,
         [")", ..current],
         acc,
       )
@@ -109,6 +112,7 @@ fn do_split_at_top_level_comma(
         rest,
         paren_depth,
         brace_depth + 1,
+        bracket_depth,
         ["{", ..current],
         acc,
       )
@@ -117,21 +121,47 @@ fn do_split_at_top_level_comma(
         rest,
         paren_depth,
         brace_depth - 1,
+        bracket_depth,
         ["}", ..current],
         acc,
       )
-    [",", ..rest] if paren_depth == 0 && brace_depth == 0 -> {
+    ["[", ..rest] ->
+      do_split_at_top_level_comma(
+        rest,
+        paren_depth,
+        brace_depth,
+        bracket_depth + 1,
+        ["[", ..current],
+        acc,
+      )
+    ["]", ..rest] ->
+      do_split_at_top_level_comma(
+        rest,
+        paren_depth,
+        brace_depth,
+        bracket_depth - 1,
+        ["]", ..current],
+        acc,
+      )
+    [",", ..rest]
+      if paren_depth == 0 && brace_depth == 0 && bracket_depth == 0
+    -> {
       let trimmed = string.trim(string.concat(list.reverse(current)))
-      do_split_at_top_level_comma(rest, paren_depth, brace_depth, [], [
-        trimmed,
-        ..acc
-      ])
+      do_split_at_top_level_comma(
+        rest,
+        paren_depth,
+        brace_depth,
+        bracket_depth,
+        [],
+        [trimmed, ..acc],
+      )
     }
     [char, ..rest] ->
       do_split_at_top_level_comma(
         rest,
         paren_depth,
         brace_depth,
+        bracket_depth,
         [char, ..current],
         acc,
       )

--- a/src/caffeine_lang/types.gleam
+++ b/src/caffeine_lang/types.gleam
@@ -893,8 +893,39 @@ fn validate_string_literal(
         value,
         validate_string_literal,
       )
+    CollectionType(List(inner)) ->
+      validate_list_default_value(inner, value, validate_string_literal)
     CollectionType(_) -> Error(Nil)
     RecordType(_) -> Error(Nil)
+  }
+}
+
+/// Validates a list default like "[200, 404]" or "[a, b]" for a `List(inner)` type.
+/// The default must be bracket-delimited, and every element must be valid for the
+/// inner type per the supplied element validator.
+fn validate_list_default_value(
+  inner: AcceptedTypes,
+  value: String,
+  validate_inner: fn(AcceptedTypes, String) -> Result(Nil, Nil),
+) -> Result(Nil, Nil) {
+  let trimmed = string.trim(value)
+  case string.starts_with(trimmed, "["), string.ends_with(trimmed, "]") {
+    True, True -> {
+      let body =
+        trimmed
+        |> string.drop_start(1)
+        |> string.drop_end(1)
+        |> string.trim
+      case body {
+        "" -> Ok(Nil)
+        _ ->
+          body
+          |> string.split(",")
+          |> list.map(string.trim)
+          |> list.try_each(validate_inner(inner, _))
+      }
+    }
+    _, _ -> Error(Nil)
   }
 }
 
@@ -1497,10 +1528,56 @@ fn resolve_modifier_to_string(
     }
     Defaulted(inner_type, default_val) -> {
       case val {
-        value.NilValue -> Ok(resolve_string(default_val))
+        value.NilValue ->
+          resolve_default_value_to_string(
+            inner_type,
+            default_val,
+            resolve_string,
+            resolve_list,
+          )
         _ -> resolve_to_string(inner_type, val, resolve_string, resolve_list)
       }
     }
+  }
+}
+
+/// Turns a Defaulted's stored default-string into a resolved output. Routes through
+/// resolve_list when the inner type is a List so list-typed defaults render as
+/// `IN (...)` rather than getting concatenated as one opaque string. Other types
+/// fall through to resolve_string (the historical behavior).
+fn resolve_default_value_to_string(
+  inner_type: AcceptedTypes,
+  default_val: String,
+  resolve_string: fn(String) -> String,
+  resolve_list: fn(List(String)) -> String,
+) -> Result(String, String) {
+  case inner_type {
+    CollectionType(List(_)) ->
+      Ok(resolve_list(parse_list_default_string(default_val)))
+    _ -> Ok(resolve_string(default_val))
+  }
+}
+
+/// Parses a serialized list default like "[200]" or "[a, b]" back into its element
+/// strings. Returns the original string wrapped in a single-element list as a
+/// best-effort fallback if it isn't bracket-delimited. Does not preserve commas
+/// embedded inside individual string elements.
+@internal
+pub fn parse_list_default_string(default_val: String) -> List(String) {
+  let trimmed = string.trim(default_val)
+  case string.starts_with(trimmed, "["), string.ends_with(trimmed, "]") {
+    True, True -> {
+      let inner =
+        trimmed
+        |> string.drop_start(1)
+        |> string.drop_end(1)
+        |> string.trim
+      case inner {
+        "" -> []
+        _ -> inner |> string.split(",") |> list.map(string.trim)
+      }
+    }
+    _, _ -> [default_val]
   }
 }
 

--- a/test/caffeine_lang/analysis/templatizer_test.gleam
+++ b/test/caffeine_lang/analysis/templatizer_test.gleam
@@ -714,6 +714,80 @@ pub fn resolve_template_test() {
       ),
       Ok("42"),
     ),
+    // Defaulted(List(Integer), [200]) with NilValue must render the default through
+    // the list resolver (issue #80). Previously it was concatenated as the literal
+    // string `[]` because list defaults were dropped at parse time.
+    #(
+      "E2E: Defaulted(List(Integer), [200]) with NilValue uses default IN clause",
+      templatizer.TemplateVariable(
+        "success_status_codes",
+        "http.status_code",
+        templatizer.Default,
+      ),
+      helpers.ValueTuple(
+        label: "success_status_codes",
+        typ: types.ModifierType(types.Defaulted(
+          types.CollectionType(types.List(
+            types.PrimitiveType(types.NumericType(types.Integer)),
+          )),
+          "[200]",
+        )),
+        value: value.NilValue,
+      ),
+      Ok("http.status_code IN (200)"),
+    ),
+    #(
+      "E2E: Defaulted(List(Integer), [200, 404]) with NilValue uses default IN clause",
+      templatizer.TemplateVariable(
+        "codes",
+        "http.status_code",
+        templatizer.Default,
+      ),
+      helpers.ValueTuple(
+        label: "codes",
+        typ: types.ModifierType(types.Defaulted(
+          types.CollectionType(types.List(
+            types.PrimitiveType(types.NumericType(types.Integer)),
+          )),
+          "[200, 404]",
+        )),
+        value: value.NilValue,
+      ),
+      Ok("http.status_code IN (200, 404)"),
+    ),
+    #(
+      "E2E: Defaulted(List(String), []) with NilValue resolves to empty",
+      templatizer.TemplateVariable("envs", "env", templatizer.Default),
+      helpers.ValueTuple(
+        label: "envs",
+        typ: types.ModifierType(types.Defaulted(
+          types.CollectionType(types.List(types.PrimitiveType(types.String))),
+          "[]",
+        )),
+        value: value.NilValue,
+      ),
+      Ok(""),
+    ),
+    // When a value is provided at the call site, the default is ignored.
+    #(
+      "E2E: Defaulted(List(Integer), [200]) with provided value uses the value",
+      templatizer.TemplateVariable(
+        "codes",
+        "http.status_code",
+        templatizer.Default,
+      ),
+      helpers.ValueTuple(
+        label: "codes",
+        typ: types.ModifierType(types.Defaulted(
+          types.CollectionType(types.List(
+            types.PrimitiveType(types.NumericType(types.Integer)),
+          )),
+          "[200]",
+        )),
+        value: value.ListValue([value.IntValue(500), value.IntValue(503)]),
+      ),
+      Ok("http.status_code IN (500, 503)"),
+    ),
   ]
   |> test_helpers.table_test_2(templatizer.resolve_template)
 }
@@ -742,6 +816,63 @@ pub fn resolve_string_value_test() {
       templatizer.TemplateVariable("foo", "foo", templatizer.Not),
       "bar",
       "!foo:bar",
+    ),
+    // Datadog requires quoting for values containing special chars (issue #81).
+    #(
+      "Default: value with embedded colons gets quoted",
+      templatizer.TemplateVariable(
+        "controller",
+        "rails.controller",
+        templatizer.Default,
+      ),
+      "api::v0::elevenlabscontroller",
+      "rails.controller:\"api::v0::elevenlabscontroller\"",
+    ),
+    #(
+      "Not: value with embedded colons gets quoted",
+      templatizer.TemplateVariable(
+        "controller",
+        "rails.controller",
+        templatizer.Not,
+      ),
+      "api::v0::elevenlabscontroller",
+      "!rails.controller:\"api::v0::elevenlabscontroller\"",
+    ),
+    #(
+      "Default: value with whitespace gets quoted",
+      templatizer.TemplateVariable("name", "service.name", templatizer.Default),
+      "my service",
+      "service.name:\"my service\"",
+    ),
+    #(
+      "Default: value with comma gets quoted",
+      templatizer.TemplateVariable("path", "url.path", templatizer.Default),
+      "a,b",
+      "url.path:\"a,b\"",
+    ),
+    #(
+      "Default: value with parens gets quoted",
+      templatizer.TemplateVariable("expr", "expr", templatizer.Default),
+      "f(x)",
+      "expr:\"f(x)\"",
+    ),
+    #(
+      "Default: wildcard value left unquoted (preserves wildcard semantics)",
+      templatizer.TemplateVariable("name", "service.name", templatizer.Default),
+      "prefix*",
+      "service.name:prefix*",
+    ),
+    #(
+      "Raw: special chars are not quoted (raw substitution)",
+      templatizer.TemplateVariable("threshold", "", templatizer.Raw),
+      "a:b",
+      "a:b",
+    ),
+    #(
+      "Default: embedded double quote gets escaped",
+      templatizer.TemplateVariable("msg", "msg", templatizer.Default),
+      "he said \"hi\"",
+      "msg:\"he said \\\"hi\\\"\"",
     ),
   ]
   |> test_helpers.table_test_2(templatizer.resolve_string_value)
@@ -793,6 +924,35 @@ pub fn resolve_list_value_test() {
       templatizer.TemplateVariable("foo", "foo", templatizer.Not),
       [],
       "",
+    ),
+    // Datadog requires quoting for elements containing special chars (issue #81).
+    #(
+      "Default: list elements with colons get individually quoted",
+      templatizer.TemplateVariable(
+        "controller",
+        "rails.controller",
+        templatizer.Default,
+      ),
+      ["api::v0::ctrl", "api::v1::ctrl"],
+      "rails.controller IN (\"api::v0::ctrl\", \"api::v1::ctrl\")",
+    ),
+    #(
+      "Default: mixed quoted and bare elements",
+      templatizer.TemplateVariable("env", "env", templatizer.Default),
+      ["prod", "us east"],
+      "env IN (prod, \"us east\")",
+    ),
+    #(
+      "Not: list elements with colons get individually quoted",
+      templatizer.TemplateVariable("path", "path", templatizer.Not),
+      ["a:b", "c:d"],
+      "path NOT IN (\"a:b\", \"c:d\")",
+    ),
+    #(
+      "Raw: list elements not quoted (raw substitution)",
+      templatizer.TemplateVariable("vals", "", templatizer.Raw),
+      ["a:b", "c"],
+      "a:b, c",
     ),
   ]
   |> test_helpers.table_test_2(templatizer.resolve_list_value)

--- a/test/caffeine_lang/compiler_test.gleam
+++ b/test/caffeine_lang/compiler_test.gleam
@@ -222,6 +222,66 @@ pub fn compile_from_strings_test() {
       ),
       True,
     ),
+    // Defaulted(List(...)) default must flow through to codegen when the field
+    // is omitted at the call site (issue #80). Previously the list contents were
+    // collapsed to "[]" at parse time and the generated query contained
+    // `http.status_code:[]` rather than `http.status_code IN (200, 404)`.
+    #(
+      "happy path - Defaulted(List(Integer)) default flows to IN clause when omitted",
+      #(
+        "_codes (Type): Defaulted(List(Integer), [200, 404])
+
+\"endpoint_success\":
+  Requires { codes: _codes, endpoint: String }
+  Provides {
+    evaluation: \"numerator / denominator\",
+    indicators: {
+      numerator: \"sum:http.requests{$endpoint->endpoint$ AND $http.status_code->codes$}\",
+      denominator: \"sum:http.requests{$endpoint->endpoint$}\"
+    }
+  }
+",
+        "Expectations measured by \"endpoint_success\"
+  * \"checkout_success\":
+    Provides {
+      endpoint: \"/checkout\",
+      threshold: 99.9%,
+      window_in_days: 30
+    }
+",
+        "acme/payments/slos.caffeine",
+        ["http.status_code IN (200, 404)"],
+      ),
+      True,
+    ),
+    // String values containing colons must be quoted in Datadog queries to avoid
+    // colliding with the tag:value syntax (issue #81).
+    #(
+      "happy path - string with colons gets quoted in Datadog query",
+      #(
+        "\"controller_success\":
+  Requires { controller: String }
+  Provides {
+    evaluation: \"numerator / denominator\",
+    indicators: {
+      numerator: \"sum:rails.action.hits{$rails.controller->controller$}\",
+      denominator: \"sum:rails.action.hits{*}\"
+    }
+  }
+",
+        "Expectations measured by \"controller_success\"
+  * \"elevenlabs_uptime\":
+    Provides {
+      controller: \"api::v0::elevenlabscontroller\",
+      threshold: 99.9%,
+      window_in_days: 30
+    }
+",
+        "acme/payments/slos.caffeine",
+        ["rails.controller:\\\"api::v0::elevenlabscontroller\\\""],
+      ),
+      True,
+    ),
     // sad path - invalid measurement DSL
     #(
       "sad path - invalid measurement DSL",

--- a/test/caffeine_lang/corpus/generator/complex_expression.tf
+++ b/test/caffeine_lang/corpus/generator/complex_expression.tf
@@ -33,7 +33,7 @@ resource "datadog_service_level_objective" "org_team_auth_composite_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Composite SLO",
+    "expectation:\"Composite SLO\"",
   ]
   type = "metric"
 

--- a/test/caffeine_lang/corpus/generator/multiple_slos.tf
+++ b/test/caffeine_lang/corpus/generator/multiple_slos.tf
@@ -33,7 +33,7 @@ resource "datadog_service_level_objective" "org_team_auth_latency_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Auth Latency SLO",
+    "expectation:\"Auth Latency SLO\"",
   ]
   type = "metric"
 
@@ -56,7 +56,7 @@ resource "datadog_service_level_objective" "org_team_api_availability_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:API Availability SLO",
+    "expectation:\"API Availability SLO\"",
   ]
   type = "metric"
 

--- a/test/caffeine_lang/corpus/generator/resolved_templates.tf
+++ b/test/caffeine_lang/corpus/generator/resolved_templates.tf
@@ -33,7 +33,7 @@ resource "datadog_service_level_objective" "org_team_auth_latency_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Auth Latency SLO",
+    "expectation:\"Auth Latency SLO\"",
   ]
   type = "metric"
 

--- a/test/caffeine_lang/corpus/generator/resolved_time_slice_expression.tf
+++ b/test/caffeine_lang/corpus/generator/resolved_time_slice_expression.tf
@@ -33,7 +33,7 @@ resource "datadog_service_level_objective" "org_team_auth_time_slice_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Time Slice SLO",
+    "expectation:\"Time Slice SLO\"",
   ]
   type = "time_slice"
 

--- a/test/caffeine_lang/corpus/generator/simple_slo.tf
+++ b/test/caffeine_lang/corpus/generator/simple_slo.tf
@@ -33,7 +33,7 @@ resource "datadog_service_level_objective" "org_team_auth_latency_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Auth Latency SLO",
+    "expectation:\"Auth Latency SLO\"",
   ]
   type = "metric"
 

--- a/test/caffeine_lang/corpus/generator/slo_with_both_dependencies.tf
+++ b/test/caffeine_lang/corpus/generator/slo_with_both_dependencies.tf
@@ -33,9 +33,9 @@ resource "datadog_service_level_objective" "org_team_auth_latency_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Auth Latency SLO",
-    "hard_dependency:db_slo,storage_slo",
-    "soft_dependency:cache_slo,logging_slo",
+    "expectation:\"Auth Latency SLO\"",
+    "hard_dependency:\"db_slo,storage_slo\"",
+    "soft_dependency:\"cache_slo,logging_slo\"",
   ]
   type = "metric"
 

--- a/test/caffeine_lang/corpus/generator/slo_with_empty_tags.tf
+++ b/test/caffeine_lang/corpus/generator/slo_with_empty_tags.tf
@@ -33,7 +33,7 @@ resource "datadog_service_level_objective" "org_team_auth_latency_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Auth Latency SLO",
+    "expectation:\"Auth Latency SLO\"",
   ]
   type = "metric"
 

--- a/test/caffeine_lang/corpus/generator/slo_with_hard_dependency_only.tf
+++ b/test/caffeine_lang/corpus/generator/slo_with_hard_dependency_only.tf
@@ -33,8 +33,8 @@ resource "datadog_service_level_objective" "org_team_auth_latency_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Auth Latency SLO",
-    "hard_dependency:db_slo,storage_slo",
+    "expectation:\"Auth Latency SLO\"",
+    "hard_dependency:\"db_slo,storage_slo\"",
   ]
   type = "metric"
 

--- a/test/caffeine_lang/corpus/generator/slo_with_mixed_dependencies.tf
+++ b/test/caffeine_lang/corpus/generator/slo_with_mixed_dependencies.tf
@@ -33,9 +33,9 @@ resource "datadog_service_level_objective" "org_team_auth_latency_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Auth Latency SLO",
+    "expectation:\"Auth Latency SLO\"",
     "hard_dependency:db_slo",
-    "soft_dependency:cache_slo,logging_slo",
+    "soft_dependency:\"cache_slo,logging_slo\"",
   ]
   type = "metric"
 

--- a/test/caffeine_lang/corpus/generator/slo_with_overshadowing_tags.tf
+++ b/test/caffeine_lang/corpus/generator/slo_with_overshadowing_tags.tf
@@ -32,7 +32,7 @@ resource "datadog_service_level_objective" "org_team_auth_latency_slo" {
     "org:org",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Auth Latency SLO",
+    "expectation:\"Auth Latency SLO\"",
     "team:override_team",
   ]
   type = "metric"

--- a/test/caffeine_lang/corpus/generator/slo_with_runbook.tf
+++ b/test/caffeine_lang/corpus/generator/slo_with_runbook.tf
@@ -34,7 +34,7 @@ resource "datadog_service_level_objective" "org_team_auth_latency_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Auth Latency SLO",
+    "expectation:\"Auth Latency SLO\"",
   ]
   type = "metric"
 

--- a/test/caffeine_lang/corpus/generator/slo_with_tags.tf
+++ b/test/caffeine_lang/corpus/generator/slo_with_tags.tf
@@ -33,7 +33,7 @@ resource "datadog_service_level_objective" "org_team_auth_latency_slo" {
     "team:test_team",
     "service:team",
     "measurement:test_measurement",
-    "expectation:Auth Latency SLO",
+    "expectation:\"Auth Latency SLO\"",
     "env:prod",
     "tier:1",
   ]

--- a/test/caffeine_lang/types_test.gleam
+++ b/test/caffeine_lang/types_test.gleam
@@ -2063,10 +2063,46 @@ pub fn parse_accepted_type_test() {
       "Defaulted(Optional(String), default)",
       Error(Nil),
     ),
-    // Invalid - Defaulted only allows primitives, refinements, or collections
+    // Defaulted(List(...)) is allowed when the default is a bracketed list literal
+    // whose elements parse as the inner type. Bareword defaults remain invalid.
     #(
-      "Defaulted wrapping List not allowed",
+      "Defaulted wrapping List with bareword default rejected",
       "Defaulted(List(String), default)",
+      Error(Nil),
+    ),
+    #(
+      "Defaulted(List(Integer)) with list literal default",
+      "Defaulted(List(Integer), [200, 404])",
+      Ok(
+        ModifierType(Defaulted(
+          CollectionType(List(PrimitiveType(NumericType(Integer)))),
+          "[200, 404]",
+        )),
+      ),
+    ),
+    #(
+      "Defaulted(List(String)) with list literal default",
+      "Defaulted(List(String), [a, b])",
+      Ok(
+        ModifierType(Defaulted(
+          CollectionType(List(PrimitiveType(String))),
+          "[a, b]",
+        )),
+      ),
+    ),
+    #(
+      "Defaulted(List(Integer)) with empty list default",
+      "Defaulted(List(Integer), [])",
+      Ok(
+        ModifierType(Defaulted(
+          CollectionType(List(PrimitiveType(NumericType(Integer)))),
+          "[]",
+        )),
+      ),
+    ),
+    #(
+      "Defaulted(List(Integer)) with non-integer element rejected",
+      "Defaulted(List(Integer), [200, abc])",
       Error(Nil),
     ),
     // Defaulted with refinement inner type (what happens after type alias resolution)


### PR DESCRIPTION
Issue #80: `Defaulted(List(T), [...])` defaults were collapsed to "[]" at parse time and routed through the string resolver at substitution, so an omitted list field rendered as `attr:[]` instead of `attr IN (...)`. literal_to_string now serializes list literals faithfully, and the Defaulted resolvers in types.gleam and ir_builder.gleam dispatch through the list path when the inner type is `List(_)`.

Issue #81: string values containing colons (e.g. `api::v0::ctrl`) were emitted unquoted into Datadog queries, colliding with the `tag:value` syntax. New `quote_for_datadog` wraps values that contain Datadog-reserved characters (colons, whitespace, commas, parens), preserves wildcards, and is applied at every emission site (string substitution, list element substitution, tag emission). Existing corpus tag fixtures with whitespace or comma values now show the (correct) quoted form.

Also makes parse_accepted_type consistent with the language parser: split_at_top_level_comma now tracks bracket depth, and validate_string_literal accepts `Defaulted(List(_), [...])` when the default is a bracketed list literal whose elements validate against the inner type.